### PR TITLE
Update Types.js

### DIFF
--- a/src/Types.js
+++ b/src/Types.js
@@ -126,7 +126,7 @@ export const types = {
     properties: {
       color: colors,
       margin: ['none', 'small', 'medium', 'large'],
-      size: ['xsmall', 'small', 'medium', 'large', 'xlarge'],
+      size: ['small', 'medium', 'large', 'xlarge', 'xxlarge'],
       textAlign: ['start', 'center', 'end'],
     },
   },


### PR DESCRIPTION
Fixing the crash of `xsmall` size for Paragraph, and allowing 'xlarge' size.