### PR TITLE
Allow button plain to have true, false, and undefined

### DIFF
--- a/src/libraries/grommet/components.js
+++ b/src/libraries/grommet/components.js
@@ -548,7 +548,7 @@ export const components = {
       hoverIndicator: false,
       href: '',
       margin: Edge,
-      plain: false,
+      plain: [true, false],
       primary: false,
       reverse: false,
       size: ['small', 'medium', 'large'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1528,9 +1528,9 @@
     "@types/react" "*"
 
 "@types/react@*":
-  version "16.9.32"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.32.tgz#f6368625b224604148d1ddf5920e4fefbd98d383"
-  integrity sha512-fmejdp0CTH00mOJmxUPPbWCEBWPvRIL4m8r0qD+BSDUqmutPyGQCHifzMpMzdvZwROdEdL78IuZItntFWgPXHQ==
+  version "16.9.33"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.33.tgz#a5274520f0d28cbbb73c8652ddd48646fd4bcae5"
+  integrity sha512-ovgoy7p9999HDzwv8Sewhl8GJjn/r0GRsFrM9UMwp1uodh0kQ0pwIHLQ6LNfqGSyjNzJ8II/HIg0BL7Yn/B9yA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -6020,6 +6020,7 @@ grommet-icons@^4.2.0:
 
 "grommet-icons@https://github.com/grommet/grommet-icons/tarball/stable":
   version "4.4.0"
+  uid "028b6a47d88edbf5f844df56f8333b588ca84f56"
   resolved "https://github.com/grommet/grommet-icons/tarball/stable#028b6a47d88edbf5f844df56f8333b588ca84f56"
   dependencies:
     grommet-styles "^0.2.0"
@@ -6031,7 +6032,8 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.12.0"
-  resolved "https://github.com/grommet/grommet/tarball/stable#bed0f225a5b58ec9219ed548a87f2faab23ea49f"
+  uid d7082918eb43783a6fb2dce5553649dea69c6ba0
+  resolved "https://github.com/grommet/grommet/tarball/stable#d7082918eb43783a6fb2dce5553649dea69c6ba0"
   dependencies:
     css "^2.2.3"
     grommet-icons "^4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6020,7 +6020,6 @@ grommet-icons@^4.2.0:
 
 "grommet-icons@https://github.com/grommet/grommet-icons/tarball/stable":
   version "4.4.0"
-  uid "028b6a47d88edbf5f844df56f8333b588ca84f56"
   resolved "https://github.com/grommet/grommet-icons/tarball/stable#028b6a47d88edbf5f844df56f8333b588ca84f56"
   dependencies:
     grommet-styles "^0.2.0"
@@ -6032,8 +6031,7 @@ grommet-styles@^0.2.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.12.0"
-  uid d7082918eb43783a6fb2dce5553649dea69c6ba0
-  resolved "https://github.com/grommet/grommet/tarball/stable#d7082918eb43783a6fb2dce5553649dea69c6ba0"
+  resolved "https://github.com/grommet/grommet/tarball/stable#e6bf36eb488abb9c09b88ab5b723527b2da2a50e"
   dependencies:
     css "^2.2.3"
     grommet-icons "^4.2.0"


### PR DESCRIPTION
Unlike other plain values, button needs to accept 'true', 'false', and undefined. By default, it will be undefined.