### PR TITLE
Fix issue with references with no component set

### DIFF
--- a/src/design/code.js
+++ b/src/design/code.js
@@ -102,12 +102,14 @@ export const generateJSX = ({
       component.type === 'Reference'
     ) {
       const nextReferenceDesign = getReferenceDesign(importsArg, component);
-      result = componentToJSX({
-        screen,
-        id: component.props.component,
-        indent,
-        referenceDesign: nextReferenceDesign,
-      });
+      result = nextReferenceDesign
+        ? componentToJSX({
+            screen,
+            id: component.props.component,
+            indent,
+            referenceDesign: nextReferenceDesign,
+          })
+        : '';
     } else {
       if (component.type === 'grommet.Layer') {
         layers[id] = true;


### PR DESCRIPTION
Signed-off-by: Josh Williams <williams.jackj@gmail.com>

This is in reference to https://github.com/grommet/grommet-designer/issues/71

To reproduce the issue, add a reference but do not point it to another component, then attempt to generate code. It will show an error in the console.

Afterwards, adding a Reference and not pointing it to another component should still generate code fine.