### PR TITLE
Change generated code to use shorthand truthy and no falsy props

### DIFF
--- a/src/design/code.js
+++ b/src/design/code.js
@@ -151,7 +151,8 @@ export const generateJSX = ({
           return !(
             (typeof value === 'object' && Object.keys(value).length === 0) ||
             value === '' ||
-            value === undefined
+            value === undefined ||
+            value === false
           );
         })
         .map(name => {
@@ -174,6 +175,9 @@ export const generateJSX = ({
               return ` ${name}={<${value} />}`;
             }
             return ` ${name}="${value}"`;
+          }
+          if (typeof value === 'boolean') {
+            return ` ${name}`;
           }
           return ` ${name}={${JSON.stringify(value)}}`;
         })

--- a/src/design/code.js
+++ b/src/design/code.js
@@ -151,8 +151,7 @@ export const generateJSX = ({
           return !(
             (typeof value === 'object' && Object.keys(value).length === 0) ||
             value === '' ||
-            value === undefined ||
-            value === false
+            value === undefined
           );
         })
         .map(name => {
@@ -176,7 +175,7 @@ export const generateJSX = ({
             }
             return ` ${name}="${value}"`;
           }
-          if (typeof value === 'boolean') {
+          if (typeof value === 'boolean' && value) {
             return ` ${name}`;
           }
           return ` ${name}={${JSON.stringify(value)}}`;


### PR DESCRIPTION
Signed-off-by: Josh Williams <williams.jackj@gmail.com>

The default code generated is a bit verbose, explicitly outputting every true / false property on every component, which goes against the typical React pattern.

Before, the code generator would output false and true props with explicit values:

<Button label="Dashboard" plain={true} primary={false} reverse={false} secondary={false} hoverIndicator={false} active={false} icon={<Dashboard />} />

Now, it will output the code in a more optimized format:

<Button label="Dashboard" plain icon={<Dashboard />} />

I understand that maybe you want all properties output, if so then feel free to reject.

Thanks for the awesome framework!