### PR TITLE
Fix copying components with deep property components

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -80,6 +80,7 @@ const Canvas = () => {
     data,
     design,
     imports,
+    libraries,
     mode,
     selected,
     setSelected,
@@ -111,11 +112,6 @@ const Canvas = () => {
   // referenced maps rendered referenced component to its Reference
   const referenced = useRef({});
   const [initialize, setInitialize] = useState({});
-
-  const libraries = useMemo(
-    () => imports.filter((i) => i.library).map((i) => i.library),
-    [imports],
-  );
 
   // clear inline edit when selection changes
   useEffect(() => {

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -3,7 +3,6 @@ import React, {
   useCallback,
   useContext,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from 'react';

--- a/src/Properties/ComponentCode.js
+++ b/src/Properties/ComponentCode.js
@@ -5,11 +5,11 @@ import DesignContext from '../DesignContext';
 import { generateJSX } from '../design';
 
 const ComponentCode = ({ component, onDone }) => {
-  const { design, imports, theme } = useContext(DesignContext);
+  const { design, imports, libraries, theme } = useContext(DesignContext);
   const [code, setCode] = useState();
   useEffect(() => {
-    setCode(generateJSX({ component, design, imports, theme }));
-  }, [component, design, imports, theme]);
+    setCode(generateJSX({ component, design, imports, libraries, theme }));
+  }, [component, design, imports, libraries, theme]);
   return (
     <Layer onClickOutside={onDone} onEsc={onDone}>
       <Header>

--- a/src/Properties/Properties.js
+++ b/src/Properties/Properties.js
@@ -185,6 +185,7 @@ const Properties = () => {
       nextDesign,
       id: selected.component,
       imports,
+      libraries,
     });
     if (newId) {
       changeDesign(nextDesign);
@@ -199,7 +200,11 @@ const Properties = () => {
 
   const duplicate = () => {
     const nextDesign = JSON.parse(JSON.stringify(design));
-    const newId = duplicateComponent(nextDesign, selected.component);
+    const newId = duplicateComponent({
+      nextDesign,
+      id: selected.component,
+      libraries,
+    });
     changeDesign(nextDesign);
     setSelected({ ...selected, component: newId });
 

--- a/src/Properties/ScreenDetails.js
+++ b/src/Properties/ScreenDetails.js
@@ -7,7 +7,7 @@ import { addScreen, deleteScreen, newFrom, slugify } from '../design';
 import TextInputField from './TextInputField';
 
 const ScreenDetails = () => {
-  const { changeDesign, design, imports, selected, setSelected } =
+  const { changeDesign, design, imports, libraries, selected, setSelected } =
     useContext(DesignContext);
   const delet = () => {
     const nextDesign = JSON.parse(JSON.stringify(design));
@@ -20,7 +20,12 @@ const ScreenDetails = () => {
   const duplicate = () => {
     const nextDesign = JSON.parse(JSON.stringify(design));
     const nextSelected = { ...selected };
-    addScreen(nextDesign, nextSelected, nextDesign.screens[selected.screen]);
+    addScreen({
+      nextDesign,
+      nextSelected,
+      copyScreen: nextDesign.screens[selected.screen],
+      libraries,
+    });
     changeDesign(nextDesign);
     setSelected(nextSelected);
   };
@@ -30,6 +35,7 @@ const ScreenDetails = () => {
       design,
       externalReferences: false,
       imports,
+      libraries,
       selected,
     });
     changeDesign(nextDesign);

--- a/src/Tree/AddComponent.js
+++ b/src/Tree/AddComponent.js
@@ -14,12 +14,8 @@ import AddComponents from './AddComponents';
 import AddLocation from './AddLocation';
 
 const AddComponent = ({ onClose }) => {
-  const { changeDesign, design, imports, selected, setSelected } =
+  const { changeDesign, design, imports, libraries, selected, setSelected } =
     useContext(DesignContext);
-  const libraries = useMemo(
-    () => imports.filter((i) => i.library).map((i) => i.library),
-    [imports],
-  );
   const [addLocation, setAddLocation] = useState();
 
   const onAdd = useCallback(
@@ -30,9 +26,9 @@ const AddComponent = ({ onClose }) => {
       if (typeName) {
         if (typeName === 'designer.Screen') {
           if (starter && starter !== 'default') {
-            copyScreen(nextDesign, nextSelected, starter);
+            copyScreen({ nextDesign, nextSelected, starter, libraries });
           } else {
-            addScreen(nextDesign, nextSelected);
+            addScreen({ nextDesign, nextSelected, libraries });
           }
         } else {
           if (starter && starter !== 'default') {
@@ -40,6 +36,7 @@ const AddComponent = ({ onClose }) => {
               nextDesign,
               templateDesign: starter.starters,
               id: starter.id,
+              libraries,
               screen: nextSelected.screen,
             });
             nextDesign.components[id].name = starter.name;
@@ -54,6 +51,7 @@ const AddComponent = ({ onClose }) => {
             nextDesign,
             templateDesign,
             id: template.id,
+            libraries,
             screen: nextSelected.screen,
           });
           nextDesign.components[id].name = template.name;
@@ -141,7 +139,12 @@ const AddComponent = ({ onClose }) => {
           </Box>
         )}
         <Box flex overflow="auto">
-          <AddComponents design={design} imports={imports} onAdd={onAdd} />
+          <AddComponents
+            design={design}
+            imports={imports}
+            libraries={libraries}
+            onAdd={onAdd}
+          />
         </Box>
       </Box>
     </Layer>

--- a/src/Tree/AddComponent.js
+++ b/src/Tree/AddComponent.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import ReactGA from 'react-ga';
 import { Box, Button, Heading, Layer } from 'grommet';
 import { Close } from 'grommet-icons';

--- a/src/Tree/AddComponents.js
+++ b/src/Tree/AddComponents.js
@@ -3,12 +3,7 @@ import { Box, Keyboard, TextInput } from 'grommet';
 import AddLibrary from './AddLibrary';
 import AddTemplate from './AddTemplate';
 
-const AddComponents = ({ design, imports, onAdd }) => {
-  const libraries = useMemo(
-    () => imports.filter((i) => i.library).map((i) => i.library),
-    [imports],
-  );
-
+const AddComponents = ({ design, imports, libraries, onAdd }) => {
   const [search, setSearch] = useState('');
 
   const inputRef = useRef();

--- a/src/Tree/Share.js
+++ b/src/Tree/Share.js
@@ -235,7 +235,7 @@ const SaveLocally = ({ onClose }) => {
 };
 
 const Developer = () => {
-  const { design, imports, theme } = useContext(DesignContext);
+  const { design, imports, libraries, theme } = useContext(DesignContext);
   const [code, setCode] = useState();
 
   return (
@@ -254,7 +254,7 @@ const Developer = () => {
           label="Generate Code"
           hoverIndicator
           onClick={() => {
-            setCode(generateJSX({ design, imports, theme }));
+            setCode(generateJSX({ design, imports, libraries, theme }));
             ReactGA.event({
               category: 'share',
               action: 'generate code',

--- a/src/Tree/Tree.js
+++ b/src/Tree/Tree.js
@@ -242,11 +242,12 @@ const Tree = () => {
       if (event.key === 'v' && (event.metaKey || event.ctrlKey)) {
         if (copied) {
           const nextDesign = JSON.parse(JSON.stringify(design));
-          const newId = duplicateComponent(
+          const newId = duplicateComponent({
             nextDesign,
-            copied.component,
-            selected.component,
-          );
+            id: copied.component,
+            libraries,
+            parentId: selected.component,
+          });
           changeDesign(nextDesign);
           setSelected({ ...selected, component: newId });
         } else {
@@ -259,6 +260,7 @@ const Tree = () => {
                 nextDesign,
                 templateDesign: copiedDesign,
                 id: copiedSelected.component,
+                libraries,
               });
               insertComponent({ nextDesign, libraries, selected, id: newId });
 

--- a/src/design/code.js
+++ b/src/design/code.js
@@ -62,9 +62,9 @@ export const generateJSX = ({
   component,
   design,
   imports: importsArg,
+  libraries,
   theme: themeArg,
 }) => {
-  const libraries = importsArg.filter((i) => i.library).map((i) => i.library);
   const imports = { Grommet: true };
   const iconImports = {};
   const theme = themeForValue(design.theme);

--- a/src/design/new.js
+++ b/src/design/new.js
@@ -8,7 +8,13 @@ const empty = {
   components: {},
 };
 
-export const newFrom = ({ design, externalReferences, imports, selected }) => {
+export const newFrom = ({
+  design,
+  externalReferences,
+  imports,
+  libraries,
+  selected,
+}) => {
   const nextDesign = setupDesign(empty);
   upgradeDesign(nextDesign);
   const screen = design.screens[selected.screen];
@@ -18,6 +24,7 @@ export const newFrom = ({ design, externalReferences, imports, selected }) => {
     templateDesign: design,
     id: selected.component || screen.root,
     imports,
+    libraries,
     screen: selected.screen,
   });
   nextDesign.name =

--- a/src/libraries/grommet/WorldMapPlaces.js
+++ b/src/libraries/grommet/WorldMapPlaces.js
@@ -28,7 +28,9 @@ const Place = ({ ComponentInput, value, onChange, ...rest }) => {
               if (!nextPlace.location) nextPlace.location = [];
               let lat = parseFloat(event.target.value, 10);
               nextPlace.location[0] =
-                `${lat}` === event.target.value ? lat : event.target.value;
+                `${lat}` === (event.target.value !== '')
+                  ? lat
+                  : event.target.value;
               setPlace(nextPlace);
             }}
           />
@@ -40,7 +42,9 @@ const Place = ({ ComponentInput, value, onChange, ...rest }) => {
               if (!nextPlace.location) nextPlace.location = [];
               let lon = parseFloat(event.target.value, 10);
               nextPlace.location[1] =
-                `${lon}` === event.target.value ? lon : event.target.value;
+                `${lon}` === (event.target.value !== '')
+                  ? lon
+                  : event.target.value;
               setPlace(nextPlace);
             }}
           />

--- a/src/libraries/grommet/components.js
+++ b/src/libraries/grommet/components.js
@@ -1602,6 +1602,19 @@ export const components = {
       }));
       return result;
     },
+    copy: (source, copy, { nextDesign, duplicateComponent }) => {
+      // duplicate any columns render components
+      if (source.props?.columns) {
+        source.props.columns.forEach((column, index) => {
+          if (column.render) {
+            copy.props.columns[index].render = duplicateComponent({
+              nextDesign,
+              id: column.render,
+            });
+          }
+        });
+      }
+    },
   },
   Distribution: {
     component: Distribution,
@@ -1938,6 +1951,19 @@ export const components = {
         }));
       }
       return result;
+    },
+    copy: (source, copy, { nextDesign, duplicateComponent }) => {
+      // duplicate any places content components
+      if (source.props?.places) {
+        source.props.places.forEach((place, index) => {
+          if (place.content) {
+            copy.props.places[index].content = duplicateComponent({
+              nextDesign,
+              id: place.content,
+            });
+          }
+        });
+      }
     },
   },
 };


### PR DESCRIPTION
The essence of this is a new hook called `copy` that allows component types to tap into when components are copied, allowing the type to determine if there is something embedded in its properties that needs copying.

See line 160 of change.js where this is called and line 1605 of the grommet components.js file for an example of using it.

The bulk of these changes are to ensure we pass `libraries` around everywhere we need it, since that's where we get the type for a component.