### PR TITLE
Make ObjectProperty 'close' height consistent 

### DIFF
--- a/src/Properties/ObjectProperty.js
+++ b/src/Properties/ObjectProperty.js
@@ -11,38 +11,41 @@ const ObjectProperty = React.forwardRef(
     const [expand, setExpand] = React.useState();
     return (
       <Box key={name}>
-        <Box flex direction="row" gap="small">
-          <Field flex label={name}>
-            {value && (
-              <Text weight="bold" truncate>
-                {jsonValue(value)}
-              </Text>
-            )}
-            <span style={{ display: 'flex' }}>
+        <Box flex direction="row">
+          <Box flex>
+            <Button ref={ref} hoverIndicator onClick={() => setExpand(!expand)}>
+              <Field flex label={name}>
+                <Box direction="row" align="center" gap="small">
+                  {value && (
+                    <Text weight="bold" truncate>
+                      {jsonValue(value)}
+                    </Text>
+                  )}
+                  <Box pad={{ vertical: 'xsmall', horizontal: 'small' }}>
+                    {expand ? (
+                      <FormUp color="control" />
+                    ) : (
+                      <FormDown color="control" />
+                    )}
+                  </Box>
+                </Box>
+              </Field>
+            </Button>
+          </Box>
+          {value && (
+            <Box flex={false} border={{ side: 'bottom' }}>
               <Button
-                ref={ref}
+                tip={`clear ${name}`}
                 hoverIndicator
-                onClick={() => setExpand(!expand)}
+                onClick={() => onChange(undefined)}
+                pad={{ vertical: 'xsmall', horizontal: 'small' }}
               >
                 <Box pad={{ vertical: 'xsmall', horizontal: 'small' }}>
-                  {expand ? (
-                    <FormUp color="control" />
-                  ) : (
-                    <FormDown color="control" />
-                  )}
+                  <FormClose />
                 </Box>
               </Button>
-              {value && (
-                <Button
-                  icon={<FormClose />}
-                  tip={`clear ${name}`}
-                  hoverIndicator
-                  onClick={() => onChange(undefined)}
-                  pad={{ vertical: 'xsmall', horizontal: 'small' }}
-                />
-              )}
-            </span>
-          </Field>
+            </Box>
+          )}
         </Box>
         {expand && (
           <Box pad={{ left: 'small' }} border="bottom">

--- a/src/Properties/ObjectProperty.js
+++ b/src/Properties/ObjectProperty.js
@@ -11,40 +11,38 @@ const ObjectProperty = React.forwardRef(
     const [expand, setExpand] = React.useState();
     return (
       <Box key={name}>
-        <Box direction="row">
-          <Box flex>
-            <Button ref={ref} hoverIndicator onClick={() => setExpand(!expand)}>
-              <Field label={name}>
-                <Box direction="row" align="center" gap="small">
-                  {value && (
-                    <Text weight="bold" truncate>
-                      {jsonValue(value)}
-                    </Text>
-                  )}
-                  <Box
-                    flex={false}
-                    pad={{ vertical: 'xsmall', horizontal: 'small' }}
-                  >
-                    {expand ? (
-                      <FormUp color="control" />
-                    ) : (
-                      <FormDown color="control" />
-                    )}
-                  </Box>
-                </Box>
-              </Field>
-            </Button>
-          </Box>
-          {value && (
-            <Box border={{ side: 'horizontal' }}>
+        <Box flex direction="row" gap="small">
+          <Field flex label={name}>
+            {value && (
+              <Text weight="bold" truncate>
+                {jsonValue(value)}
+              </Text>
+            )}
+            <span style={{ display: 'flex' }}>
               <Button
-                icon={<FormClose />}
-                tip={`clear ${name}`}
+                ref={ref}
                 hoverIndicator
-                onClick={() => onChange(undefined)}
-              />
-            </Box>
-          )}
+                onClick={() => setExpand(!expand)}
+              >
+                <Box pad={{ vertical: 'xsmall', horizontal: 'small' }}>
+                  {expand ? (
+                    <FormUp color="control" />
+                  ) : (
+                    <FormDown color="control" />
+                  )}
+                </Box>
+              </Button>
+              {value && (
+                <Button
+                  icon={<FormClose />}
+                  tip={`clear ${name}`}
+                  hoverIndicator
+                  onClick={() => onChange(undefined)}
+                  pad={{ vertical: 'xsmall', horizontal: 'small' }}
+                />
+              )}
+            </span>
+          </Field>
         </Box>
         {expand && (
           <Box pad={{ left: 'small' }} border="bottom">


### PR DESCRIPTION
Fixes #135  by making the composition of the `ObjectProperty` component closer to that of the `FunctionProperty`.

Now it looks like this: 

![image](https://github.com/grommet/grommet-designer/assets/11338926/c9763c5d-762c-4eb8-89c4-ba35a4169cf0)

`test`, `e2e`, and `prettier` all pass.